### PR TITLE
Individual scripts for adding units

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length=120

--- a/README.md
+++ b/README.md
@@ -8,10 +8,4 @@ Please see [this wiki page](https://github.com/juju-solutions/bundle-canonical-k
 
 - Can't build cross-platform tarballs. If you want a tarball for s390x, you'll need to
 build it on s390x.
-- juju add-unit is going to fail because each new node needs to have the core snap copied over and installed.
-- If the machine numbers aren't 0,1,2,3... things are gonna break.
-
-## TODO
-
-- Write an add-unit script that handles adding a machine, installing the core snap, and adding a unit of X to that machine.
-- Handle machine numbers better, and don't forget about the add-unit script.
+- juju add-unit without a --to directive is going to fail because each new node needs to have the core snap copied over and installed.

--- a/shrinkwrap.py
+++ b/shrinkwrap.py
@@ -21,6 +21,89 @@ def get_args():
     return parser.parse_args()
 
 
+def get_machine_count(applications_to_deploy, subordinates):
+    machineCount = 0
+    for appname, app in applications_to_deploy.items():
+        if appname not in subordinates:
+            machineCount += app['NumUnits']
+
+    return machineCount
+
+
+def build_deploy_script(script_filename, bundle, subordinates, applications_to_deploy=None):
+    # Figure out how many machines we'll need.
+    if applications_to_deploy:
+        machineCount = get_machine_count(applications_to_deploy, subordinates)
+    else:
+        machineCount = get_machine_count(bundle, subordinates)
+
+    attach = []
+    deploy = []
+    relate = []
+
+    # Commands for creating machines and waiting on them to be live..
+    deploy.append("MACHINES=$(juju add-machine -n %d 2>&1|awk '{print $3}')" % machineCount)
+    deploy.append("set +x")
+    deploy.append("until [[ %d =~ `juju machines | grep started | wc -l` ]]; do sleep 1; echo Waiting for machines to start...; done" % machineCount) # noqa
+    deploy.append("set -x")
+
+    # Let's just install snap core on everything. TODO: don't do this on machines we don't need snaps on.
+    deploy.append('for machine in $MACHINES; do')
+    deploy.append('  juju scp %s $machine:' % (os.path.join('resources', 'core.snap')))
+    deploy.append('  juju run --machine $machine "sudo snap install --dangerous /home/ubuntu/core.snap"')
+    deploy.append('done')
+    deploy.append('MACHINE_LIST=($MACHINES)')
+
+    if applications_to_deploy:
+        # Commands for adding a unit to machines.
+        machine_index = 0
+        for appname, app in bundle['applications'].items():
+            if appname not in applications_to_deploy:
+                continue
+            deploy.append("juju add-unit --to ${MACHINE_LIST[%d]} ./charms/%s" % (machine_index, appname))
+            machine_index += 1
+    else:
+        # Commands for deploying charms to machines.
+        machine_index = 0
+        for appname, app in bundle['applications'].items():
+            resource_list = []
+            for resource in app['resources']:
+                resource_list.append("--resource %s=%s" % (resource['Name'],
+                                                           os.path.join('.', 'resources',
+                                                                        appname, resource['filename'])))
+            if appname in subordinates:
+                deploy.append("juju deploy %s ./charms/%s" % (" ".join(resource_list), appname))
+            else:
+                num_list = []
+                for x in range(app['NumUnits']):
+                    num_list.append("${MACHINE_LIST[%d]}" % (machine_index))
+                    machine_index += 1
+
+                deploy.append("juju deploy -n {} {} --to {} ./charms/{}".format(app['NumUnits'],
+                                                                                " ".join(resource_list),
+                                                                                ",".join(num_list),
+                                                                                appname))
+
+        # Commands for relating charms.
+        for relation in bundle['Relations']:
+            relate.append('juju relate %s %s' % (relation[0], relation[1]))
+
+    # Write the deployment script.
+    with open(script_filename, 'w') as sh:
+        sh.write('#!/bin/bash\n\n')
+        sh.write('set -eux\n\n')
+        for cmd in deploy:
+            sh.write(cmd + '\n')
+        for cmd in attach:
+            sh.write(cmd + '\n')
+        for cmd in relate:
+            sh.write(cmd + '\n')
+
+    # Make the deployment script executable.
+    st = os.stat(script_filename)
+    os.chmod(script_filename, st.st_mode | stat.S_IEXEC)
+
+
 def main():
     args = get_args()
 
@@ -37,9 +120,6 @@ def main():
     os.makedirs(root)
     os.makedirs('%s/charms' % root)
     os.makedirs('%s/resources' % root)
-
-    # Keep track of commands for attaching resources to applications.
-    attach = []
 
     # Keep track of subordinate applications.
     subordinates = []
@@ -66,6 +146,7 @@ def main():
         # Get the charm resources metadata.
         resp = requests.get('https://api.jujucharms.com/charmstore/v5/%s/meta/resources' % id)
         resources = json.loads(resp.text)
+        bundle['applications'][appname]['resources'] = resources
 
         # Create a path to store the charm resources.
         os.makedirs(os.path.join(root, 'resources', appname))
@@ -76,7 +157,8 @@ def main():
             # Create the filename from the snap Name and Path extension. Use this instead of just Path because
             # multiple resources can have the same names for Paths.
             extension = os.path.splitext(resource['Path'])[1]
-            filename = resource['Name'] + extension;
+            filename = resource['Name'] + extension
+            resource['filename'] = filename
 
             print('    Downloading resource %s...' % filename)
 
@@ -96,7 +178,8 @@ def main():
                     config = yaml.load(stream)
                     if 'options' in config:
                         if 'channel' in config['options']:
-                            channel = config['options']['channel']['default'] # Might need to check if this is nonsensical
+                            # Might need to check if this is nonsensical
+                            channel = config['options']['channel']['default']
 
                 # Path without .snap extension is currently a match for the name in the snap store. This may not always
                 # be the case.
@@ -109,63 +192,25 @@ def main():
 
             # This isn't a snap, do it the easy way.
             else:
-                url = 'https://api.jujucharms.com/charmstore/v5/%s/resource/%s/%d' % (id, resource['Name'], resource['Revision'])
+                url = 'https://api.jujucharms.com/charmstore/v5/%s/resource/%s/%d' % (id,
+                                                                                      resource['Name'],
+                                                                                      resource['Revision'])
                 check_call(('wget --quiet %s -O %s' % (url, path)).split())
 
-            # Store a juju command for attaching the resource.
-            attach.append('juju attach %s %s=%s' % (appname, resource['Name'], os.path.join('.', 'resources', appname, filename)))
-
+    print('Writing deploy scripts...')
+    build_deploy_script(os.path.join(root, 'deploy.sh'), bundle, subordinates)
+    print('    deploy.sh')
+    for appname, app in bundle['applications'].items():
+        script_filename = os.path.join(root, 'add-unit-{}.sh'.format(appname))
+        app_to_deploy = {appname: app}
+        build_deploy_script(script_filename, bundle, subordinates, app_to_deploy)
+        print('    add-unit-{}.sh'.format(script_filename))
 
     # Download the core snap.
     print('Downloading the core snap...')
     check_output('snap download core --channel=stable'.split(), stderr=STDOUT)
     check_call('mv core*.snap %s' % os.path.join(root, 'resources', 'core.snap'), shell=True)
     check_call('rm *.assert', shell=True)
-
-    # Figure out how many machines we'll need. TODO: this should take into account the number of units defined by the bundle.
-    machineCount = sum([1 for appname in bundle['applications'] if appname not in subordinates])
-
-    # Commands for creating machines and waiting on them to be live..
-    deploy = []
-    deploy.append("juju add-machine -n %d" % machineCount)
-    deploy.append("set +x")
-    deploy.append("until [[ %d =~ `juju machines | grep started | wc -l` ]]; do sleep 1; echo Waiting for machines to start...; done" % machineCount)
-    deploy.append("set -x")
-
-    # Let's just install snap core on everything. TODO: don't do this on machines we don't need snaps on.
-    for machine in range(machineCount):
-        deploy.append('juju scp %s %d:' % (os.path.join('resources', 'core.snap'), machine))
-        deploy.append('juju run --machine %d "sudo snap install --dangerous /home/ubuntu/core.snap"' % machine)
-
-    # Commands for deploying charms to machines.
-    machine = 0
-    for appname, app in bundle['applications'].items():
-        if appname in subordinates:
-            deploy.append("juju deploy ./charms/%s" % appname)
-        else:
-            deploy.append("juju deploy --to %d ./charms/%s" % (machine, appname))
-            machine += 1
-
-    # Commands for relating charms.
-    relate = []
-    for relation in bundle['Relations']:
-        relate.append('juju relate %s %s' % (relation[0], relation[1]))
-
-    # Write the deployment script.
-    shpath = os.path.join(root, 'deploy.sh')
-    with open(shpath, 'w') as sh:
-        sh.write('#!/bin/bash\n\n')
-        sh.write('set -eux\n\n')
-        for cmd in deploy:
-            sh.write(cmd + '\n')
-        for cmd in attach:
-            sh.write(cmd + '\n')
-        for cmd in relate:
-            sh.write(cmd + '\n')
-
-    # Make the deployment script executable.
-    st = os.stat(shpath)
-    os.chmod(shpath, st.st_mode | stat.S_IEXEC)
 
     # Make the tarball.
     check_call(('tar -czf %s.tar.gz %s' % (root, root)), shell=True)

--- a/shrinkwrap.py
+++ b/shrinkwrap.py
@@ -37,7 +37,6 @@ def build_deploy_script(script_filename, bundle, subordinates, applications_to_d
     else:
         machineCount = get_machine_count(bundle, subordinates)
 
-    attach = []
     deploy = []
     relate = []
 
@@ -93,8 +92,6 @@ def build_deploy_script(script_filename, bundle, subordinates, applications_to_d
         sh.write('#!/bin/bash\n\n')
         sh.write('set -eux\n\n')
         for cmd in deploy:
-            sh.write(cmd + '\n')
-        for cmd in attach:
             sh.write(cmd + '\n')
         for cmd in relate:
             sh.write(cmd + '\n')


### PR DESCRIPTION
* Removed the machine numbering requirement.
* Added per-application scripts to add a new unit.
* Fixed machine numbering issues.
* Added support for honoring the number of units in the bundle for each application.
* Updated README

